### PR TITLE
Move news to _data, filter in front page instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ sudo gem install rouge
 jekyll serve
 ```
 
-## Add posts
+## Editing the lab website
+
+Below, we explain how to edit the lab webpage
+
+### Add posts
 
 It's very easy to add post. All the posts are located in `_posts` folder. It arrangement is based on
 date. Each post can be written in markdown format. You just have to state headers before writing: `title`, `description` and `categories`. `description` will be shown when you share on social media like Facebook or twitter. See the following headers:
@@ -27,7 +31,7 @@ categories: scientists
 
 We have 4 categories: `scientists`, `students`, `discussion`, `blog` you can choose and this will be rendered to different location.
 
-## How to add posts
+### How to add posts
 
 - **Directly edit on Github**, you can simply go to `_posts` and click `New file` then put some markdown file e.g. `2016-02-03-post-name.md` and start writing blog post. Github also allows you to preview it so it's nice for people who don't want to clone the repo. 
 
@@ -35,7 +39,7 @@ We have 4 categories: `scientists`, `students`, `discussion`, `blog` you can cho
 
 The changes will take approximately half a minute to render. You can see the new posts or changes on [kordinglab.com](http://kordinglab.github.io/)!
 
-## Add yourself
+### Add yourself
 
 You can add yourself to the page in `_people` folder just create file name `<firstname>_<lastname>.md` in the folder. We require few line of header before you start writing your own page. See the following for the header
 
@@ -52,6 +56,10 @@ joined: 2014
 If you don't have information, just leave it blank. The avatar will bring photo from `images/people` folder and display it on people page. 
 For lab position, you can choose position from 4 classes including `postdoc`, `gradstudent`, `visiting`, `others` (so called Honorary members). Position will put you into section that you choose.
 
-## Add new publications
+### Add new publications
 
 All publications from the lab are located in `publications.md`. Please upload new publication on your own!
+
+### Add news
+
+All news presented in the front page by editing `_data/news.yml`. There are some symbol that cannot be used directly e.g. `:`, be careful

--- a/_data/news.yml
+++ b/_data/news.yml
@@ -1,0 +1,26 @@
+- date: 2019-11-20
+  details: Titipat made an awesome <a href="http://35.160.123.103/">"Events at Penn" app</a> that allows you to make search and recommendation on all events at Penn
+
+- date: 2019-11-10
+  details: Konrad submitted a giant U19 grant proposal on credit assignment in the brain (auditory/striatal circuits) with many collaborators.
+
+- date: 2019-11-10
+  details: Konrad gave a colloquim at John Hopkins, <a href="https://pbs.jhu.edu/event/colloquium-konrad-kording/">“Bayesian Behavior vs Bayesian Brains.”</a>
+
+- date: 2019-11-01
+  details: Roozbeh presented a poster at <a href="https://deepmath-conference.com/presentations">DeepMath</a> called "PDE description of tree functions with repeated inputs". The poster is <a href= "https://www.dropbox.com/s/37z0hdnu47hd1qy/bare_conf_deepmath.pdf?dl=0">available here.</a>
+
+- date: 2019-11-01
+  details: Roozbeh presented a poster at SfN 2019. <a href="https://www.abstractsonline.com/pp8/#!/7883/presentation/50793">"Molecular Mechanisms of Axon and Dendrite Development" </a>
+
+- date: 2019-10-28
+  details: Ilenna passed her qualifying exam in the neuroscience department!
+
+- date: 2019-10-25
+  details: New preprint - <a href="https://www.biorxiv.org/content/10.1101/780478v1">Hue tuning curves in V4 change with visual context</a>
+
+- date: 2019-10-10
+  details: Ari traveled to Berlin to present <a href="https://ccneuro.org/2019/Papers/ViewPapers.asp?PaperNum=1299">Shared visual illusions between humans and artificial neural networks</a> at CCN and "Hue tuning curves in V4 change with visual context" at the Bernstein conference.
+
+- date: 2019-10-05
+  details: Nidhi visited the Human Performance Lab at the University of Calgary,

--- a/_data/news.yml
+++ b/_data/news.yml
@@ -23,4 +23,5 @@
   details: Ari traveled to Berlin to present <a href="https://ccneuro.org/2019/Papers/ViewPapers.asp?PaperNum=1299">Shared visual illusions between humans and artificial neural networks</a> at CCN and "Hue tuning curves in V4 change with visual context" at the Bernstein conference.
 
 - date: 2019-10-05
-  details: Nidhi visited the Human Performance Lab at the University of Calgary,
+  details: Nidhi visited the Human Performance Lab at the University of Calgary, gave a seminar titled "Data-driven and normative models of human movement from in-the-lab to the real world", and led a 3-day workshop on "Intro to Deep Learning with PyTorch".
+

--- a/index.html
+++ b/index.html
@@ -25,21 +25,20 @@ layout: default
           <u>Happenings of the last two months. Updated 11/18/2019</u>
           <span style="display: block; margin-bottom: 1em"></span>
           <div class="news">
-
-            <ul style="list-style-position:outside;padding:20px" >
-               <li><span> Konrad submitted a giant U19 grant proposal on credit assignment in the brain (auditory/striatal circuits) with many collaborators.
-               <li><span> Konrad gave a colloquim at John Hopkins: <a href="https://pbs.jhu.edu/event/colloquium-konrad-kording/">“Bayesian Behavior vs Bayesian Brains.”</a>
-               <li><span>  Roozbeh presented a poster at <a href="https://deepmath-conference.com/presentations">DeepMath</a> called "PDE description of tree functions with repeated inputs". The poster is <a href= "https://www.dropbox.com/s/37z0hdnu47hd1qy/bare_conf_deepmath.pdf?dl=0">available here.</a>
-               <li><span>  Roozbeh presented a poster at SfN 2019. Title: <a href="https://www.abstractsonline.com/pp8/#!/7883/presentation/50793">"Molecular Mechanisms of Axon and Dendrite Development" </a>
-               <li><span> Ilenna passed her qualifying exam in the neuroscience department!
-               <li><span> New preprint: <a href="https://www.biorxiv.org/content/10.1101/780478v1">Hue tuning curves in V4 change with visual context</a>
-               <li><span> Ari traveled to Berlin to present <a href="https://ccneuro.org/2019/Papers/ViewPapers.asp?PaperNum=1299">Shared visual illusions between humans and artificial neural networks</a>
-                 at CCN and "Hue tuning curves in V4 change with visual context" at the Bernstein conference.
-               <li><span> Nidhi visited the Human Performance Lab at the University of Calgary,
-                 gave a seminar titled "Data-driven and normative models of human movement: from in-the-lab to the real world", and
-                  led a 3-day workshop on "Intro to Deep Learning with PyTorch".
+              {% capture now %}{{'now' | date: '%s' | minus: 36288000 %}}{% endcapture %}
+              <ul style="list-style-position:outside;padding:20px" >
+                {% for new in site.data.news %}
+                  {% capture date %}{{new.date | date: '%s' | plus: 0 %}}{% endcapture %}
+                  {% if date > now %}
+                    <li>
+                      <span>
+                        {{ new.details }}
+                      </span>
+                    </li>
+                  {% endif %}
+                {% endfor %}
               </ul>
-            </div>
+          </div>
         </div >
       </div>
 

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@ layout: default
           <u>Happenings of the last two months. Updated 11/18/2019</u>
           <span style="display: block; margin-bottom: 1em"></span>
           <div class="news">
-              {% capture now %}{{'now' | date: '%s' | minus: 36288000 %}}{% endcapture %}
+              {% capture now %}{{'now' | date: '%s' | minus: 5184000 %}}{% endcapture %}
               <ul style="list-style-position:outside;padding:20px" >
                 {% for new in site.data.news %}
                   {% capture date %}{{new.date | date: '%s' | plus: 0 %}}{% endcapture %}


### PR DESCRIPTION
- Move `news` to `_data` folder so that we can collect as many as possible
- Filter date through a liquid tag instead

Reference: https://stackoverflow.com/questions/7087376/comparing-dates-in-liquid/23025858#23025858