### PR TITLE
index: remove duplicate city, state, zip

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@ layout: default
 
       <span style="display: block; margin-bottom: 3em"></span>
       Department of Bioengineering and Department of Neuroscience at University of Pennsylvania<br>
-      404 Richards Building, 3700 Hamilton Walk, Philadelphia, PA 19104, Philadelphia, PA 19104
+      404 Richards Building, 3700 Hamilton Walk, Philadelphia, PA 19104
       <span style="display: block; margin-bottom: 3em"></span>
 
     </header>


### PR DESCRIPTION
Right now, the address at the bottom of the [home page](https://kordinglab.com) lists the city, state, and zip twice. 

Let's clean that up to only specify those fields once.

Here's a screenshot of what this looks like after the change:
<img width="663" alt="Screenshot 2024-03-05 at 9 14 36 PM" src="https://github.com/KordingLab/KordingLab.github.io/assets/50264607/eb9ddae8-68b5-4e42-9fef-3e750c7713b6">
